### PR TITLE
#9 - Video position bug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ group :development, :test do
   gem 'vcr'
   gem 'selenium-webdriver'
   gem 'chromedriver-helper'
+  gem 'table_print'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -296,6 +296,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    table_print (1.5.6)
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
@@ -361,6 +362,7 @@ DEPENDENCIES
   selenium-webdriver
   shoulda-matchers
   simplecov
+  table_print
   tzinfo-data
   vcr
   web-console (>= 3.3.0)

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -2,4 +2,7 @@ class Video < ApplicationRecord
   has_many :user_videos
   has_many :users, through: :user_videos
   belongs_to :tutorial
+
+  # validations
+  validates_presence_of :position, numericality: { greater_than_or_equal_to: 0 }
 end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -40,6 +40,6 @@
       </section>
     </section>
   <% else %>
-    <%= link_to 'Connect to GitHub', '/auth/github' %> 
+    <%= link_to 'Connect to GitHub', '/auth/github' %>
   <% end %>
 </section>

--- a/lib/tasks/set_video_positions.rake
+++ b/lib/tasks/set_video_positions.rake
@@ -1,0 +1,20 @@
+# lib/tasks/set_video_positions.rake
+
+namespace :videos do
+  desc 'Set missing video positions in db'
+    task set_position_if_missing: :environment do
+      while Video.where(position: nil).exists?
+        Video.where(position: nil).each do |null_pos_vid|
+          videos = Video.where(tutorial_id: null_pos_vid.tutorial_id)
+
+          @position_counter = 1
+          videos.each do |video|
+            video.update(position: @position_counter)
+            @position_counter += 1
+          end
+        end
+      end
+
+      puts "All video positions have been updated."
+    end
+end

--- a/lib/tasks/set_video_positions.rake
+++ b/lib/tasks/set_video_positions.rake
@@ -15,6 +15,6 @@ namespace :videos do
         end
       end
 
-      puts "All video positions have been updated."
+      puts 'All video positions have been updated.'
     end
 end

--- a/spec/factories/videos.rb
+++ b/spec/factories/videos.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
     description { Faker::SiliconValley.motto }
     video_id { Faker::Crypto.md5 }
     tutorial
+    sequence(:position) { |n| n + 1 }
   end
 end

--- a/spec/models/video_spec.rb
+++ b/spec/models/video_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe Video, type: :model do
+  describe 'validations' do
+    it { should validate_presence_of :position }
+  end
+end


### PR DESCRIPTION
What does this PR do?

This pull request adds a validation to the Video model so a number is required for a Video position along. Adjusting the Video factory so that positions are included was also necessary with the new validation to pass prior tests.

This pull request also adds a rake task so that positions are automatically added to records if they're already in the Video table with a NULL value for position. The rake task can be run in the command line using:

`bundle exec rake videos:set_position_if_missing`