### PR TITLE
Tutorial Missing Videos bug

### DIFF
--- a/app/views/tutorials/show.html.erb
+++ b/app/views/tutorials/show.html.erb
@@ -2,68 +2,72 @@
 <h2><%= @facade.title %></h2>
 <h1 id="message"></h1>
 <div class="col col-4">
-  <h4>Videos</h4>
-  <ul>
-    <% @facade.videos.each do |video| %>
-      <li>
-        <h3><%= link_to video.title, tutorial_path(video_id: video.id), class: "show-link", id: video.position %></h3>
-      </li>
-    <% end %>
-  </ul>
-</div>
-
-<div class="col col-8">
-  <div class="title-bookmark">
-    <h3><%= @facade.current_video.title %></h3>
-    <div class="bookmarks-btn">
-      <% if current_user %>
-      <%= button_to "Bookmark", user_videos_path(video_id: @facade.current_video.id, user_id: current_user.id), method: :post, class: "btn btn-outline mb1 teal" %>
-      <% else %>
-      <%= link_to "Bookmark", login_path, class: "btn btn-outline mb1 teal" %>
+  <% if @facade.videos.any? %>
+    <h4>Videos</h4>
+    <ul>
+      <% @facade.videos.each do |video| %>
+        <li>
+          <h3><%= link_to video.title, tutorial_path(video_id: video.id), class: "show-link", id: video.position %></h3>
+        </li>
       <% end %>
-    </div>
+    </ul>
   </div>
 
-  <div id="player">
-    <script src="https://www.youtube.com/player_api"></script>
-    <script>
-    // create youtube player
-    var player;
-    var position;
-    function onYouTubePlayerAPIReady() {
-      player = new YT.Player('player', {
-        width: '640',
-        height: '390',
-        videoId: '<%= @facade.current_video.video_id %>',
-        events: {
-          onReady: onPlayerReady,
-          onStateChange: onPlayerStateChange
-        }
-      });
-    }
+  <div class="col col-8">
+    <div class="title-bookmark">
+      <h3><%= @facade.current_video.title %></h3>
+      <div class="bookmarks-btn">
+        <% if current_user %>
+        <%= button_to "Bookmark", user_videos_path(video_id: @facade.current_video.id, user_id: current_user.id), method: :post, class: "btn btn-outline mb1 teal" %>
+        <% else %>
+        <%= link_to "Bookmark", login_path, class: "btn btn-outline mb1 teal" %>
+        <% end %>
+      </div>
+    </div>
 
-    // autoplay video
-    function onPlayerReady(event) {
-      event.target.playVideo();
-    }
-
-    // when video ends
-    function onPlayerStateChange(event) {
-      if(event.data === 0 && <%= @facade.play_next_video? %>) {
-        window.location = "/tutorials/<%=@facade.id%>?video_id=<%=@facade.next_video.id %>";
-      } else if(event.data === 0 && <%= @facade.play_next_video? == false %>) {
-        const message = document.querySelector(`#message`);
-        message.innerHTML = "You watched them all. Bask in the glory of your new skills."
+    <div id="player">
+      <script src="https://www.youtube.com/player_api"></script>
+      <script>
+      // create youtube player
+      var player;
+      var position;
+      function onYouTubePlayerAPIReady() {
+        player = new YT.Player('player', {
+          width: '640',
+          height: '390',
+          videoId: '<%= @facade.current_video.video_id %>',
+          events: {
+            onReady: onPlayerReady,
+            onStateChange: onPlayerStateChange
+          }
+        });
       }
-    }
-  </script>
-</div>
 
-  <h4>Description</h4>
-  <p data-controller="tutorials" id="description-<%= @facade.current_video.id %>">
-    <%= @facade.current_video.description.truncate(50) %>...
-    <%= link_to "More", "#", "data-action" => "click->tutorials#showDescription", id: @facade.current_video.id, class: "show-link"%>
-  </p>
-</div>
+      // autoplay video
+      function onPlayerReady(event) {
+        event.target.playVideo();
+      }
+
+      // when video ends
+      function onPlayerStateChange(event) {
+        if(event.data === 0 && <%= @facade.play_next_video? %>) {
+          window.location = "/tutorials/<%=@facade.id%>?video_id=<%=@facade.next_video.id %>";
+        } else if(event.data === 0 && <%= @facade.play_next_video? == false %>) {
+          const message = document.querySelector(`#message`);
+          message.innerHTML = "You watched them all. Bask in the glory of your new skills."
+        }
+      }
+    </script>
+  </div>
+
+    <h4>Description</h4>
+    <p data-controller="tutorials" id="description-<%= @facade.current_video.id %>">
+      <%= @facade.current_video.description.truncate(50) %>...
+      <%= link_to "More", "#", "data-action" => "click->tutorials#showDescription", id: @facade.current_video.id, class: "show-link"%>
+    </p>
+  </div>
+<% else %>
+  <p>There are no videos in this tutorial yet!</p>
+<% end %>
 
 </main>

--- a/spec/features/tutorials/new_tutorial_with_no_videos_does_not_error_spec.rb
+++ b/spec/features/tutorials/new_tutorial_with_no_videos_does_not_error_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe 'When viewing a Tutorial page', type: :feature do
+  context 'And the Tutorial does not have any videos' do
+    it 'will display a message on the page, and the rendering will not error' do
+      tutorial = create(:tutorial)
+
+      visit tutorial_path(tutorial)
+
+      expect(page).to have_content(tutorial.title)
+      expect(page).to have_content('There are no videos in this tutorial yet!')
+    end
+  end
+end


### PR DESCRIPTION
This PR brings in the functionality to cover a situation where a Tutorial does not have any videos. Previously, the app would error out when viewing the Tutorial page because the method `title` could not be called on `current_video`, as there was no videos to be current.

resolves #8 