### PR TITLE
Backfill Model Specs

### DIFF
--- a/spec/models/git_hub/repository_spec.rb
+++ b/spec/models/git_hub/repository_spec.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe GitHub::Repository do
   before :each do
-    attributes = { name: "Repository the Whirlwind",
-                   html_url: "https://getsome.com" }
+    attributes = { name: 'Repository the Whirlwind',
+                   html_url: 'https://getsome.com' }
 
     @repository = GitHub::Repository.new(attributes)
   end
@@ -13,7 +15,7 @@ RSpec.describe GitHub::Repository do
   end
 
   it 'attributes' do
-    expect(@repository.name).to eq("Repository the Whirlwind")
-    expect(@repository.html_url).to eq("https://getsome.com")
+    expect(@repository.name).to eq('Repository the Whirlwind')
+    expect(@repository.html_url).to eq('https://getsome.com')
   end
 end

--- a/spec/models/git_hub/repository_spec.rb
+++ b/spec/models/git_hub/repository_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe GitHub::Repository do
+  before :each do
+    attributes = { name: "Repository the Whirlwind",
+                   html_url: "https://getsome.com" }
+
+    @repository = GitHub::Repository.new(attributes)
+  end
+
+  it 'exists' do
+    expect(@repository).to be_a(GitHub::Repository)
+  end
+
+  it 'attributes' do
+    expect(@repository.name).to eq("Repository the Whirlwind")
+    expect(@repository.html_url).to eq("https://getsome.com")
+  end
+end

--- a/spec/models/git_hub/user_spec.rb
+++ b/spec/models/git_hub/user_spec.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe GitHub::User do
   before :each do
-    attributes = { login: "Joey Bagodonuts",
-                   html_url: "https://joeytime.com" }
+    attributes = { login: 'Joey Bagodonuts',
+                   html_url: 'https://joeytime.com' }
 
     @user = GitHub::User.new(attributes)
   end
@@ -13,7 +15,7 @@ RSpec.describe GitHub::User do
   end
 
   it 'attributes' do
-    expect(@user.name).to eq("Joey Bagodonuts")
-    expect(@user.html_url).to eq("https://joeytime.com")
+    expect(@user.name).to eq('Joey Bagodonuts')
+    expect(@user.html_url).to eq('https://joeytime.com')
   end
 end

--- a/spec/models/git_hub/user_spec.rb
+++ b/spec/models/git_hub/user_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe GitHub::User do
+  before :each do
+    attributes = { login: "Joey Bagodonuts",
+                   html_url: "https://joeytime.com" }
+
+    @user = GitHub::User.new(attributes)
+  end
+
+  it 'existance' do
+    expect(@user).to be_a(GitHub::User)
+  end
+
+  it 'attributes' do
+    expect(@user.name).to eq("Joey Bagodonuts")
+    expect(@user.html_url).to eq("https://joeytime.com")
+  end
+end

--- a/spec/models/tutorial_spec.rb
+++ b/spec/models/tutorial_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe Tutorial, type: :model do
   describe 'relationships' do
     it { should have_many :videos }
+    it { should accept_nested_attributes_for :videos }
   end
 
   describe 'instance methods' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe User, type: :model do
     it '#connect_github' do
       user = create(:user)
 
-      auth_hash = { uid: 12345678,
+      auth_hash = { uid: 12_345_678,
                     credentials: { token: 'b1ria2na3nd4bre5n6na7na8re9th10e11b13est' } }
 
       expect(user.github_uid).to eq(nil)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,9 +2,18 @@ require 'rails_helper'
 
 RSpec.describe User, type: :model do
   describe 'validations' do
-    it {should validate_presence_of(:email)}
-    it {should validate_presence_of(:first_name)}
-    it {should validate_presence_of(:password)}
+    it { should validate_presence_of :email }
+    it { should validate_uniqueness_of :email }
+
+    it { should have_secure_password }
+    it { should validate_presence_of :password }
+
+    it { should validate_presence_of :first_name }
+  end
+
+  describe 'relationships' do
+    it { should have_many :user_videos }
+    it { should have_many(:videos).through(:user_videos) }
   end
 
   describe 'roles' do
@@ -12,14 +21,32 @@ RSpec.describe User, type: :model do
       user = User.create(email: 'user@email.com', password: 'password', first_name:'Jim', role: 0)
 
       expect(user.role).to eq('default')
-      expect(user.default?).to be_truthy
+      expect(user.default?).to(be_truthy)
     end
 
     it 'can be created as an Admin user' do
       admin = User.create(email: 'admin@email.com', password: 'admin', first_name:'Bob', role: 1)
 
       expect(admin.role).to eq('admin')
-      expect(admin.admin?).to be_truthy
+      expect(admin.admin?).to(be_truthy)
+    end
+  end
+
+  describe 'instance methods' do
+    it '#connect_github' do
+      user = create(:user)
+
+      auth_hash = { uid: 12345678,
+                    credentials: { token: 'b1ria2na3nd4bre5n6na7na8re9th10e11b13est' } }
+
+      expect(user.github_uid).to eq(nil)
+      expect(user.github_token).to eq(nil)
+
+      user.connect_github(auth_hash)
+      user.reload
+
+      expect(user.github_uid.to_i).to eq(auth_hash[:uid])
+      expect(user.github_token).to eq(auth_hash[:credentials][:token])
     end
   end
 end

--- a/spec/models/user_video_spec.rb
+++ b/spec/models/user_video_spec.rb
@@ -1,4 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe UserVideo, type: :model do
+  describe 'relationships' do
+    it { should belong_to :video}
+    it { should belong_to :user}
+  end
 end

--- a/spec/models/user_video_spec.rb
+++ b/spec/models/user_video_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe UserVideo, type: :model do
   describe 'relationships' do
-    it { should belong_to :video}
-    it { should belong_to :user}
+    it { should belong_to :video }
+    it { should belong_to :user }
   end
 end


### PR DESCRIPTION
This PR backfills validation, relationship and instance method specs for all models except Videos. Specs for existence and attributes have been added to POROS except for the YouTube::Video. Coverage is still sitting below 10%.