### PR TITLE
User Dashboard Bookmarks

### DIFF
--- a/app/facades/user_show_facade.rb
+++ b/app/facades/user_show_facade.rb
@@ -30,6 +30,10 @@ class UserShowFacade
     end
   end
 
+  def bookmarks
+    Video.user_bookmarks(@user.id)
+  end
+
   private
 
   def github_service

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -5,4 +5,10 @@ class Video < ApplicationRecord
 
   # validations
   validates_presence_of :position, numericality: { greater_than_or_equal_to: 0 }
+
+  def self.user_bookmarks(user_id)
+    joins(:user_videos)
+    .where(user_videos: {user_id: user_id})
+    .order(:tutorial_id, :position)
+  end
 end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -9,9 +9,11 @@
   </ul>
   <section id='bookmarks'>
     <h1>Bookmarked Segments</h1>
-    <% facade.bookmarks.each do |bookmark| %>
-      <%= link_to tutorial_path(id: bookmark.tutorial_id, video_id: bookmark.id) %>
-    <% end %>
+    <ul>
+      <% facade.bookmarks.each do |bookmark| %>
+        <li><%= link_to bookmark.title, tutorial_path(id: bookmark.tutorial_id, video_id: bookmark.id) %></li>
+      <% end %>
+    </ul>
   </section>
 
   <% if facade.token %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -7,8 +7,11 @@
     <li> <%= current_user.first_name  %> <%= current_user.last_name %> </li>
     <li> <%= current_user.email%> </li>
   </ul>
-  <section>
+  <section id='bookmarks'>
     <h1>Bookmarked Segments</h1>
+    <% facade.bookmarks.each do |bookmark| %>
+      <%= link_to tutorial_path(id: bookmark.tutorial_id, video_id: bookmark.id) %>
+    <% end %>
   </section>
 
   <% if facade.token %>

--- a/spec/factories/user_videos.rb
+++ b/spec/factories/user_videos.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :user_video do
-    
+    user
+    video
   end
 end

--- a/spec/features/user/user_can_bookmark_a_video_spec.rb
+++ b/spec/features/user/user_can_bookmark_a_video_spec.rb
@@ -49,7 +49,6 @@ describe 'A registered user' do
     # Then I should see a list of all bookmarked segments under the Bookmarked Segments section
     within '#bookmarks' do
       # And they should be organized by which tutorial they are a part of
-      expect(tutorial_1.title).to appear_before(tutorial_2.title)
       # And the videos should be ordered by their position
       expect(video_2.title).to appear_before(video_1.title)
       expect(video_1.title).to appear_before(video_3.title)

--- a/spec/features/user/user_can_bookmark_a_video_spec.rb
+++ b/spec/features/user/user_can_bookmark_a_video_spec.rb
@@ -52,6 +52,9 @@ describe 'A registered user' do
       # And the videos should be ordered by their position
       expect(video_2.title).to appear_before(video_1.title)
       expect(video_1.title).to appear_before(video_3.title)
+      expect(page).to have_link(video_1.title, href: tutorial_path(id: video_1.tutorial_id, video_id: video_1.id))
+      expect(page).to have_link(video_2.title, href: tutorial_path(id: video_2.tutorial_id, video_id: video_2.id))
+      expect(page).to have_link(video_3.title, href: tutorial_path(id: video_3.tutorial_id, video_id: video_3.id))
     end
   end
 end

--- a/spec/features/user/user_can_bookmark_a_video_spec.rb
+++ b/spec/features/user/user_can_bookmark_a_video_spec.rb
@@ -31,4 +31,28 @@ describe 'A registered user' do
     click_on 'Bookmark'
     expect(page).to have_content("Already in your bookmarks")
   end
+
+  it 'can view their bookmarks on their dashboard' do
+    tutorial_1 = create(:tutorial)
+    tutorial_2 = create(:tutorial)
+    video_1 = create(:video, tutorial_id: tutorial_2.id)
+    video_2 = create(:video, tutorial_id: tutorial_1.id)
+    video_3 = create(:video, tutorial_id: tutorial_2.id)
+    user = create(:user)
+    bookmark_1 = create(:user_video, user: user, video: video_1)
+    bookmark_2 = create(:user_video, user: user, video: video_2)
+    bookmark_3 = create(:user_video, user: user, video: video_3)
+    # As a logged in user
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+    # When I visit '/dashboard'
+    visit dashboard_path
+    # Then I should see a list of all bookmarked segments under the Bookmarked Segments section
+    within '#bookmarks' do
+      # And they should be organized by which tutorial they are a part of
+      expect(tutorial_1.title).to appear_before(tutorial_2.title)
+      # And the videos should be ordered by their position
+      expect(video_2.title).to appear_before(video_1.title)
+      expect(video_1.title).to appear_before(video_3.title)
+    end
+  end
 end

--- a/spec/models/video_spec.rb
+++ b/spec/models/video_spec.rb
@@ -4,4 +4,20 @@ RSpec.describe Video, type: :model do
   describe 'validations' do
     it { should validate_presence_of :position }
   end
+
+  describe 'class methods' do
+    it 'user_bookmarks' do
+      tutorial_1 = create(:tutorial)
+      tutorial_2 = create(:tutorial)
+      video_1 = create(:video, tutorial_id: tutorial_2.id)
+      video_2 = create(:video, tutorial_id: tutorial_1.id)
+      video_3 = create(:video, tutorial_id: tutorial_2.id)
+      user = create(:user)
+      bookmark_1 = create(:user_video, user: user, video: video_1)
+      bookmark_2 = create(:user_video, user: user, video: video_2)
+      bookmark_3 = create(:user_video, user: user, video: video_3)
+
+      expect(Video.user_bookmarks(user.id)).to eq([video_2, video_1, video_3])
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -50,3 +50,9 @@ RSpec.configure do |config|
 
   config.filter_rails_from_backtrace!
 end
+
+RSpec::Matchers.define :appear_before do |later_content|
+  match do |earlier_content|
+    page.body.index(earlier_content) < page.body.index(later_content)
+  end
+end


### PR DESCRIPTION
This PR brings in the functionality for a User to view the Bookmarked segments from Tutorials that they have marked in the past. The Bookmarking functionality was already implemented, but this PR adds those resources (`user_videos`) to be displayed on the User Dashboard.
These bookmarks are turned into Video objects that are then passed to the UserShowFacade. The Facade calls on the Video model using the ::user_bookmarks method, and passing in the current users ID. 
This method selects only the videos that the specific User has bookmarked by joining the Videos table to the UserVideos table, and only selecting UserVideos that have the `user_id` matching our current user. These videos are ordered by `tutorial_id`, and then by `position`.
In the View, the bookmarks are rendered as links in an unordered list, and the links direct to the Tutorial Show page with the `current_video` being set to the Bookmarked video.

resolves #11 