### PR TITLE
User to User Friendships

### DIFF
--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 class FriendshipsController < ApplicationController
   def create
     new_friend = User.find_by(github_uid: friendship_params[:uid])
-    friendship = Friendship.new({user: current_user, friend: new_friend})
+    friendship = Friendship.new(user: current_user, friend: new_friend)
     if friendship.save
       flash[:notice] = "Congrats, you are now friends with #{new_friend.first_name + ' ' + new_friend.last_name}!"
     else

--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -1,0 +1,18 @@
+class FriendshipsController < ApplicationController
+  def create
+    new_friend = User.find_by(github_uid: friendship_params[:uid])
+    friendship = Friendship.new({user: current_user, friend: new_friend})
+    if friendship.save
+      flash[:notice] = "Congrats, you are now friends with #{new_friend.first_name + ' ' + new_friend.last_name}!"
+    else
+      flash[:danger] = 'Oops! Something went wrong!'
+    end
+    redirect_to dashboard_path
+  end
+
+  private
+
+  def friendship_params
+    params.permit(:uid)
+  end
+end

--- a/app/models/friendship.rb
+++ b/app/models/friendship.rb
@@ -1,0 +1,4 @@
+class Friendship < ApplicationRecord
+  belongs_to :user
+  belongs_to :friend, class_name: 'User'
+end

--- a/app/models/friendship.rb
+++ b/app/models/friendship.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Friendship < ApplicationRecord
   belongs_to :user
   belongs_to :friend, class_name: 'User'

--- a/app/models/git_hub/user.rb
+++ b/app/models/git_hub/user.rb
@@ -1,11 +1,15 @@
-module GitHub
-  class User
-    attr_reader :name,
-                :html_url
+class GitHub::User
+  attr_reader :name,
+              :html_url,
+              :uid
 
-    def initialize(attributes)
-      @name = attributes[:login]
-      @html_url = attributes[:html_url]
-    end
+  def initialize(attributes)
+    @name = attributes[:login]
+    @html_url = attributes[:html_url]
+    @uid = attributes[:id]
+  end
+
+  def registered?
+    !User.find_by(github_uid: @uid).nil?
   end
 end

--- a/app/models/git_hub/user.rb
+++ b/app/models/git_hub/user.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class GitHub::User
   attr_reader :name,
               :html_url,

--- a/app/models/git_hub/user.rb
+++ b/app/models/git_hub/user.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class GitHub::User
   attr_reader :name,
               :html_url,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,9 @@ class User < ApplicationRecord
   has_many :user_videos
   has_many :videos, through: :user_videos
 
+  has_many :friendships
+  has_many :friends, through: :friendships
+
   validates :email, uniqueness: true, presence: true
   validates_presence_of :first_name
   enum role: [:default, :admin]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,4 +20,9 @@ class User < ApplicationRecord
   def friendships?
     friendships.count > 0
   end
+
+  def friends?(github_user)
+    friend = User.find_by(github_uid: github_user.uid)
+    friends.include?(friend)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,4 +13,8 @@ class User < ApplicationRecord
     update_attributes(github_token: auth_hash[:credentials][:token])
     update_attributes(github_uid: auth_hash[:uid])
   end
+
+  def friendships?
+    friendships.count > 0
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,7 +18,7 @@ class User < ApplicationRecord
   end
 
   def friendships?
-    friendships.count > 0
+    friendships.count.positive?
   end
 
   def friends?(github_user)

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -11,6 +11,15 @@
     <h1>Bookmarked Segments</h1>
   </section>
 
+  <section class='friendships'>
+    <h1>Friends</h1>
+    <% if current_user.friendships? %>
+      <p>You have friends!</p>
+    <% else %>
+      <p>You have no friends :(</p>
+    <% end %>
+  </section>
+
   <% if facade.token %>
     <section class='github-dashboard'>
       <h1>GitHub</h1>
@@ -40,6 +49,6 @@
       </section>
     </section>
   <% else %>
-    <%= link_to 'Connect to GitHub', '/auth/github' %> 
+    <%= link_to 'Connect to GitHub', '/auth/github' %>
   <% end %>
 </section>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -37,7 +37,7 @@
           <% facade.followers.each do |user| %>
             <div id="github-follower-<%= user.name %>">
               <li><%= link_to user.name, user.html_url %></li>
-              <% if user.registered? %>
+              <% if user.registered? && !current_user.friends?(user) %>
                 <%= button_to 'Add as Friend', add_friend_path(user.uid) %>
               <% end %>
             </div>
@@ -48,7 +48,12 @@
         <h3>Following</h3>
           <ul>
           <% facade.following.each do |user| %>
+          <div id="github-following-<%= user.name %>">
             <li><%= link_to user.name, user.html_url %></li>
+            <% if user.registered? && !current_user.friends?(user) %>
+              <%= button_to 'Add as Friend', add_friend_path(user.uid) %>
+            <% end %>
+          </div>
           <% end %>
           </ul>
       </section>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -35,7 +35,12 @@
         <h3>Followers</h3>
           <ul>
           <% facade.followers.each do |user| %>
-            <li><%= link_to user.name, user.html_url %></li>
+            <div id="github-follower-<%= user.name %>">
+              <li><%= link_to user.name, user.html_url %></li>
+              <% if user.registered? %>
+                <%= button_to 'Add as Friend', add_friend_path(user.uid) %>
+              <% end %>
+            </div>
           <% end %>
           </ul>
       </section>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -14,7 +14,9 @@
   <section class='friendships'>
     <h1>Friends</h1>
     <% if current_user.friendships? %>
-      <p>You have friends!</p>
+      <% current_user.friends.each do |friend| %>
+        <p><%= friend.first_name + ' ' + friend.last_name %></p>
+      <% end %>
     <% else %>
       <p>You have no friends :(</p>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,8 @@ Rails.application.routes.draw do
 
   resources :users, only: [:new, :create, :update, :edit]
 
+  post '/add_friend/:uid', to: 'friendships#create', as: 'add_friend'
+
   resources :tutorials, only: [:show, :index] do
     resources :videos, only: [:show, :index]
   end

--- a/db/migrate/20190706213315_create_friendships.rb
+++ b/db/migrate/20190706213315_create_friendships.rb
@@ -1,0 +1,12 @@
+class CreateFriendships < ActiveRecord::Migration[5.2]
+  def change
+    create_table :friendships do |t|
+      t.references :user, foreign_key: true
+      t.bigint :friend_id
+
+      t.timestamps
+    end
+    add_foreign_key :friendships, :users, column: :friend_id
+    add_index :friendships, [:user_id, :friend_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_06_003159) do
+ActiveRecord::Schema.define(version: 2019_07_06_213315) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "friendships", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "friend_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id", "friend_id"], name: "index_friendships_on_user_id_and_friend_id", unique: true
+    t.index ["user_id"], name: "index_friendships_on_user_id"
+  end
 
   create_table "taggings", id: :serial, force: :cascade do |t|
     t.integer "tag_id"
@@ -82,6 +91,8 @@ ActiveRecord::Schema.define(version: 2019_07_06_003159) do
     t.index ["tutorial_id"], name: "index_videos_on_tutorial_id"
   end
 
+  add_foreign_key "friendships", "users"
+  add_foreign_key "friendships", "users", column: "friend_id"
   add_foreign_key "user_videos", "users"
   add_foreign_key "user_videos", "videos"
 end

--- a/spec/features/user/user_can_make_friends_spec.rb
+++ b/spec/features/user/user_can_make_friends_spec.rb
@@ -75,6 +75,10 @@ RSpec.describe 'As a registered user', type: :feature do
         expect(page).to_not have_button('Add as Friend')
       end
       expect(page).to have_content("Congrats, you are now friends with #{patrick.first_name + ' ' + patrick.last_name}!")
+
+      within('.friendships') do
+        expect(page).to have_content(patrick.first_name + ' ' + patrick.last_name)
+      end
     end
   end
 end

--- a/spec/features/user/user_can_make_friends_spec.rb
+++ b/spec/features/user/user_can_make_friends_spec.rb
@@ -17,5 +17,32 @@ RSpec.describe 'As a registered user', type: :feature do
         expect(page).to have_content('You have no friends :(')
       end
     end
+
+    it 'I can see Add as Friend button on unfriended users' do
+      brian = create(:user, github_uid: '43261385')
+      brennan = create(:user, github_uid: '45154998')
+      kyle = create(:user, github_uid: '46171611')
+      stella = create(:user)
+
+      VCR.use_cassette('github_dashboard') do
+        visit dashboard_path
+      end
+
+      within('#github-follower-bplantico') do
+        expect(page).to have_button('Add as Friend')
+      end
+
+      within('#github-follower-BrennanAyers') do
+        expect(page).to have_button('Add as Friend')
+      end
+
+      within('#github-follower-kylecornellissen') do
+        expect(page).to have_button('Add as Friend')
+      end
+
+      within('#github-follower-smainar') do
+        expect(page).to_not have_button('Add as Friend')
+      end
+    end
   end
 end

--- a/spec/features/user/user_can_make_friends_spec.rb
+++ b/spec/features/user/user_can_make_friends_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe 'As a registered user', type: :feature do

--- a/spec/features/user/user_can_make_friends_spec.rb
+++ b/spec/features/user/user_can_make_friends_spec.rb
@@ -20,9 +20,9 @@ RSpec.describe 'As a registered user', type: :feature do
 
     it 'I can see Add as Friend button on unfriended users' do
       brian = create(:user, github_uid: '43261385')
-      brennan = create(:user, github_uid: '45154998')
+      patrick = create(:user, github_uid: '32880860')
       kyle = create(:user, github_uid: '46171611')
-      stella = create(:user)
+      ryan = create(:user)
 
       VCR.use_cassette('github_dashboard') do
         visit dashboard_path
@@ -32,15 +32,15 @@ RSpec.describe 'As a registered user', type: :feature do
         expect(page).to have_button('Add as Friend')
       end
 
-      within('#github-follower-BrennanAyers') do
+      within('#github-follower-patrickshobe') do
         expect(page).to have_button('Add as Friend')
       end
 
-      within('#github-follower-kylecornellissen') do
+      within('#github-follower-kylecornelissen') do
         expect(page).to have_button('Add as Friend')
       end
 
-      within('#github-follower-smainar') do
+      within('#github-follower-ryanmillergm') do
         expect(page).to_not have_button('Add as Friend')
       end
     end

--- a/spec/features/user/user_can_make_friends_spec.rb
+++ b/spec/features/user/user_can_make_friends_spec.rb
@@ -54,10 +54,7 @@ RSpec.describe 'As a registered user', type: :feature do
     end
 
     it 'I can Add a Friend using the button on unfriended users' do
-      brian = create(:user, github_uid: '43261385')
       patrick = create(:user, github_uid: '32880860')
-      kyle = create(:user, github_uid: '46171611')
-      ryan = create(:user)
 
       VCR.use_cassette('github_dashboard') do
         visit dashboard_path
@@ -78,6 +75,36 @@ RSpec.describe 'As a registered user', type: :feature do
 
       within('.friendships') do
         expect(page).to have_content(patrick.first_name + ' ' + patrick.last_name)
+      end
+    end
+
+    it 'I can not add a friend using an invalid user id' do
+      patrick = create(:user, github_uid: '32880860')
+
+      VCR.use_cassette('github_dashboard') do
+        visit dashboard_path
+      end
+
+      patrick.update!(github_uid: nil)
+      patrick.reload
+
+      VCR.use_cassette('github_dashboard') do
+        within('#github-follower-patrickshobe') do
+          click_on('Add as Friend')
+        end
+      end
+
+      expect(current_path).to eq(dashboard_path)
+
+      within('#github-follower-patrickshobe') do
+        expect(page).to_not have_button('Add as Friend')
+      end
+      
+      expect(page).to_not have_content("Congrats, you are now friends with #{patrick.first_name + ' ' + patrick.last_name}!")
+      expect(page).to have_content('Oops! Something went wrong!')
+
+      within('.friendships') do
+        expect(page).to_not have_content(patrick.first_name + ' ' + patrick.last_name)
       end
     end
   end

--- a/spec/features/user/user_can_make_friends_spec.rb
+++ b/spec/features/user/user_can_make_friends_spec.rb
@@ -44,5 +44,29 @@ RSpec.describe 'As a registered user', type: :feature do
         expect(page).to_not have_button('Add as Friend')
       end
     end
+
+    it 'I can Add a Friend using the button on unfriended users' do
+      brian = create(:user, github_uid: '43261385')
+      patrick = create(:user, github_uid: '32880860')
+      kyle = create(:user, github_uid: '46171611')
+      ryan = create(:user)
+
+      VCR.use_cassette('github_dashboard') do
+        visit dashboard_path
+      end
+
+      VCR.use_cassette('github_dashboard') do
+        within('#github-follower-patrickshobe') do
+          click_on('Add as Friend')
+        end
+      end
+
+      expect(current_path).to eq(dashboard_path)
+
+      within('#github-follower-patrickshobe') do
+        expect(page).to_not have_button('Add as Friend')
+      end
+      expect(page).to have_content("Congrats, you are now friends with #{patrick.first_name + ' ' + patrick.last_name}!")
+    end
   end
 end

--- a/spec/features/user/user_can_make_friends_spec.rb
+++ b/spec/features/user/user_can_make_friends_spec.rb
@@ -8,7 +8,9 @@ RSpec.describe 'As a registered user', type: :feature do
     end
 
     it 'I can see a Friendship section' do
-      visit dashboard_path
+      VCR.use_cassette('github_dashboard') do
+        visit dashboard_path
+      end
 
       within('.friendships') do
         expect(page).to have_content('Friends')

--- a/spec/features/user/user_can_make_friends_spec.rb
+++ b/spec/features/user/user_can_make_friends_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe 'As a registered user', type: :feature do
+  context 'When I visit my dashboard' do
+    before :each do
+      @user = create(:user, github_token: '12345', github_uid: '09876')
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+    end
+
+    it 'I can see a Friendship section' do
+      visit dashboard_path
+
+      within('.friendships') do
+        expect(page).to have_content('Friends')
+        expect(page).to have_content('You have no friends :(')
+      end
+    end
+  end
+end

--- a/spec/features/user/user_can_make_friends_spec.rb
+++ b/spec/features/user/user_can_make_friends_spec.rb
@@ -43,6 +43,14 @@ RSpec.describe 'As a registered user', type: :feature do
       within('#github-follower-ryanmillergm') do
         expect(page).to_not have_button('Add as Friend')
       end
+
+      within('#github-following-bplantico') do
+        expect(page).to have_button('Add as Friend')
+      end
+
+      within('#github-following-kylecornelissen') do
+        expect(page).to have_button('Add as Friend')
+      end
     end
 
     it 'I can Add a Friend using the button on unfriended users' do

--- a/spec/features/user/user_can_make_friends_spec.rb
+++ b/spec/features/user/user_can_make_friends_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rails_helper'
 
 RSpec.describe 'As a registered user', type: :feature do
@@ -99,7 +100,7 @@ RSpec.describe 'As a registered user', type: :feature do
       within('#github-follower-patrickshobe') do
         expect(page).to_not have_button('Add as Friend')
       end
-      
+
       expect(page).to_not have_content("Congrats, you are now friends with #{patrick.first_name + ' ' + patrick.last_name}!")
       expect(page).to have_content('Oops! Something went wrong!')
 

--- a/spec/models/friendship_spec.rb
+++ b/spec/models/friendship_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rails_helper'
 
 RSpec.describe Friendship, type: :model do

--- a/spec/models/friendship_spec.rb
+++ b/spec/models/friendship_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe Friendship, type: :model do
+  describe 'relationships' do
+    it { should belong_to :user }
+    it { should belong_to :friend }
+  end
+end

--- a/spec/models/friendship_spec.rb
+++ b/spec/models/friendship_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Friendship, type: :model do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,6 +7,11 @@ RSpec.describe User, type: :model do
     it {should validate_presence_of(:password)}
   end
 
+  describe 'relationships' do
+    it { should have_many :friendships }
+    it { should have_many(:friends).through(:friendships) }
+  end
+
   describe 'roles' do
     it 'can be created as default user' do
       user = User.create(email: 'user@email.com', password: 'password', first_name:'Jim', role: 0)


### PR DESCRIPTION
This PR brings in the functionality for a User to add other Users as Friends. These friendships are made between Users find Friends when they follow or are followed by the other User on Github, and they are also a User with their Github UID/token on our site.
This required a Friendship joins table, but this joins table joins Users to other Users. Users now have a Friends collection that contains other User objects.
When our User Dashboard is rendering the Following/Followers for a User, it will check for each Github::User if they are `registered?` in our Database, and also if the `current_user` is not friends with that user in our database. If both equate to true, it will provide a Add as Friend button underneath.
This button sends a post request to our FriendshipsController, which then creates a Friendship resource to join the `current_user` to their new Friend.
If the Friendship is successful, our `current_user` will be served a confirmation message stating who they are now friends with, and adding their new Friends name to their Friends list. If they somehow request to friend a user who is no longer friendable, they will be given a danger message that lets them know something went wrong, and the DB will not be modified.


resolves #12 