### PR TITLE
6 Email Invitations

### DIFF
--- a/app/controllers/invite_controller.rb
+++ b/app/controllers/invite_controller.rb
@@ -1,0 +1,5 @@
+class InviteController < ApplicationController
+  def new
+
+  end
+end

--- a/app/controllers/invite_controller.rb
+++ b/app/controllers/invite_controller.rb
@@ -1,5 +1,21 @@
 class InviteController < ApplicationController
   def new
+  end
 
+  def create
+    email = github_service.email_query(params[:github_handle])
+    if email
+      InviteMailer.invite_email(current_user, email).deliver_now
+      flash[:success] = 'Successfully sent invite!'
+    else
+      flash[:danger] = "The Github user you selected doesn't have an email address associated with their account."
+    end
+    redirect_to dashboard_path
+  end
+
+  private
+
+  def github_service
+    GithubService.new(ENV['GITHUB-TOKEN'])
   end
 end

--- a/app/controllers/invite_controller.rb
+++ b/app/controllers/invite_controller.rb
@@ -3,9 +3,10 @@ class InviteController < ApplicationController
   end
 
   def create
-    email = github_service.email_query(params[:github_handle])
-    if email
-      InviteMailer.invite_email(current_user, email).deliver_now
+    query = github_service.user_query(params[:github_handle])
+    invitee = GitHub::User.new(query)
+    if invitee.email
+      InviteMailer.invite_email(current_user, invitee).deliver_now
       flash[:success] = 'Successfully sent invite!'
     else
       flash[:danger] = "The Github user you selected doesn't have an email address associated with their account."
@@ -16,6 +17,6 @@ class InviteController < ApplicationController
   private
 
   def github_service
-    GithubService.new(ENV['GITHUB-TOKEN'])
+    GithubService.new(current_user.github_token)
   end
 end

--- a/app/controllers/invite_controller.rb
+++ b/app/controllers/invite_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class InviteController < ApplicationController
   def new
   end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
+  default from: 'no-reply@brownest-field.herokuapp.com'
   layout 'mailer'
 end

--- a/app/mailers/invite_mailer.rb
+++ b/app/mailers/invite_mailer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class InviteMailer < ApplicationMailer
   def invite_email(user, invitee)
     @user = user

--- a/app/mailers/invite_mailer.rb
+++ b/app/mailers/invite_mailer.rb
@@ -1,0 +1,8 @@
+class InviteMailer < ApplicationMailer
+  def invite_email(user, invitee)
+    @user = user
+    @invitee = invitee
+
+    mail(to: invitee.email, subject: "#{user.github_login} has invited you to join the Brownfield project!")
+  end
+end

--- a/app/models/git_hub/user.rb
+++ b/app/models/git_hub/user.rb
@@ -3,12 +3,14 @@
 class GitHub::User
   attr_reader :name,
               :html_url,
-              :uid
+              :uid,
+              :email
 
   def initialize(attributes)
     @name = attributes[:login]
     @html_url = attributes[:html_url]
     @uid = attributes[:id]
+    @email = attributes[:email]
   end
 
   def registered?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,7 @@ class User < ApplicationRecord
 
   def connect_github(auth_hash)
     update_attributes(github_token: auth_hash[:credentials][:token])
+    update_attributes(github_login: auth_hash[:login])
     update_attributes(github_uid: auth_hash[:uid])
   end
 

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -3,8 +3,8 @@ class GithubService
     @user_token = user_token
   end
 
-  def email_query(github_handle)
-    get_json("/users/#{github_handle}")[:email]
+  def user_query(github_handle)
+    get_json("/users/#{github_handle}")
   end
 
   def followers_by_user

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -3,6 +3,10 @@ class GithubService
     @user_token = user_token
   end
 
+  def email_query(github_handle)
+    get_json("/users/#{github_handle}")[:email]
+  end
+
   def followers_by_user
     get_json('/user/followers')
   end

--- a/app/views/invite/new.html.erb
+++ b/app/views/invite/new.html.erb
@@ -1,0 +1,5 @@
+<%= form_tag invite_path, method: :post do %>
+  <%= label_tag :github_handle %>
+  <%= text_field_tag :github_handle %>
+  <%= submit_tag 'Send Invite' %>
+<% end %>

--- a/app/views/invite_mailer/invite_email.html.erb
+++ b/app/views/invite_mailer/invite_email.html.erb
@@ -1,0 +1,5 @@
+<p>
+  Hello <%= @invitee.name %>,
+
+  <%= @user.github_login %> has invited you to join the Brownest Field project. You can create an account <%= link_to 'here.', register_url %>
+</p>

--- a/app/views/invite_mailer/invite_email.text.erb
+++ b/app/views/invite_mailer/invite_email.text.erb
@@ -1,0 +1,5 @@
+<p>
+  Hello <%= @invitee.name %>,
+
+  <%= @user.github_login %> has invited you to join the Brownest Field project. You can create an account <%= link_to 'here.', register_url %>
+</p>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -16,6 +16,11 @@
     </ul>
   </section>
 
+  <section>
+    <h1>Invite a Friend</h1>
+    <%= link_to 'Send an Invite', invite_path %>
+  </section>
+
   <section class='friendships'>
     <h1>Friends</h1>
     <% if current_user.friendships? %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,15 +19,15 @@ Bundler.require(*Rails.groups)
 
 module PersonalProject
   class Application < Rails::Application
-    # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 5.2
+   config.action_mailer.delivery_method = :smtp
 
-    # Settings in config/environments/* take precedence over those specified here.
-    # Application configuration can go into files in config/initializers
-    # -- all .rb files in that directory are automatically loaded after loading
-    # the framework and any gems in your application.
-
-    # Don't generate system test files.
-    config.generators.system_tests = nil
+   config.action_mailer.smtp_settings = {
+     address:              'smtp.sendgrid.net',
+     port:                 '587',
+     domain:               'https://brownest-field.herokuapp.com/',
+     authorization:        "Bearer #{ENV['SENDGRID-API-KEY']}",
+     authentication:       :plain,
+     enable_starttls_auto: true
+   }
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,15 +19,15 @@ Bundler.require(*Rails.groups)
 
 module PersonalProject
   class Application < Rails::Application
-   config.action_mailer.delivery_method = :smtp
+    config.action_mailer.delivery_method = :smtp
 
-   config.action_mailer.smtp_settings = {
-     address:              'smtp.sendgrid.net',
-     port:                 '587',
-     domain:               'https://brownest-field.herokuapp.com/',
-     authorization:        "Bearer #{ENV['SENDGRID-API-KEY']}",
-     authentication:       :plain,
-     enable_starttls_auto: true
-   }
+    config.action_mailer.smtp_settings = {
+      address:              'smtp.sendgrid.net',
+      port:                 '587',
+      domain:               'https://brownest-field.herokuapp.com/',
+      authorization:        "Bearer #{ENV['SENDGRID-API-KEY']}",
+      authentication:       :plain,
+      enable_starttls_auto: true
+    }
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -29,11 +29,15 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
+  # SMTP configuration with ActionMailer
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = { address: 'localhost', port: 1025 }
+
   # Store uploaded files on the local file system (see config/storage.yml for options)
   config.active_storage.service = :local
 
-  # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  # Do care if the mailer can't send.
+  config.action_mailer.raise_delivery_errors = true
 
   config.action_mailer.perform_caching = false
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -32,6 +32,7 @@ Rails.application.configure do
   # SMTP configuration with ActionMailer
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = { address: 'localhost', port: 1025 }
+  config.action_mailer.default_url_options = { host: 'localhost:3000' }
 
   # Store uploaded files on the local file system (see config/storage.yml for options)
   config.active_storage.service = :local

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -18,6 +18,8 @@ Rails.application.configure do
     'Cache-Control' => "public, max-age=#{1.hour.to_i}"
   }
 
+  config.action_mailer.default_url_options = { host: 'localhost:3000' }
+
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,8 @@ Rails.application.routes.draw do
 
   resources :users, only: [:new, :create, :update, :edit]
 
+  get '/invite', to: 'invite#new'
+
   post '/add_friend/:uid', to: 'friendships#create', as: 'add_friend'
 
   resources :tutorials, only: [:show, :index] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,14 +24,14 @@ Rails.application.routes.draw do
     end
   end
 
-  get '/login', to: 'sessions#new'
-  post '/login', to: 'sessions#create'
+  get    '/login',  to: 'sessions#new'
+  post   '/login',  to: 'sessions#create'
   delete '/logout', to: 'sessions#destroy'
 
   get '/auth/:provider/callback', to: 'oauth#update'
 
-  get '/dashboard', to: 'users#show'
-  get '/about', to: 'about#show'
+  get '/dashboard',   to: 'users#show'
+  get '/about',       to: 'about#show'
   get '/get_started', to: 'get_started#show'
 
   # Is this being used?
@@ -39,7 +39,8 @@ Rails.application.routes.draw do
 
   resources :users, only: [:new, :create, :update, :edit]
 
-  get '/invite', to: 'invite#new'
+  get  '/invite', to: 'invite#new'
+  post '/invite', to: 'invite#create'
 
   post '/add_friend/:uid', to: 'friendships#create', as: 'add_friend'
 

--- a/db/migrate/20190709214355_add_git_hub_username_to_users.rb
+++ b/db/migrate/20190709214355_add_git_hub_username_to_users.rb
@@ -1,0 +1,5 @@
+class AddGitHubUsernameToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :github_login, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_06_213315) do
+ActiveRecord::Schema.define(version: 2019_07_09_214355) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -78,6 +78,7 @@ ActiveRecord::Schema.define(version: 2019_07_06_213315) do
     t.datetime "updated_at", null: false
     t.string "github_token"
     t.string "github_uid"
+    t.string "github_login"
     t.index ["email"], name: "index_users_on_email"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -126,5 +126,5 @@ m3_tutorial.videos.create!({
 })
 
 User.create!(email: 'admin@example.com', first_name: 'Bossy', last_name: 'McBosserton', password: 'password', role: :admin)
-User.create!(email: 'user1@example.com', first_name: 'Ricky', last_name: 'Bobby', password: 'password', github_token: ENV['GITHUB-TOKEN'], role: :default)
+User.create!(email: 'user1@example.com', first_name: 'Ricky', last_name: 'Bobby', password: 'password', github_token: ENV['GITHUB-TOKEN'], github_login: 'number1orbust', role: :default)
 User.create!(email: 'user2@example.com', first_name: 'Jean', last_name: 'Girard', password: 'password')

--- a/spec/cassettes/send-email-failure.yml
+++ b/spec/cassettes/send-email-failure.yml
@@ -1,0 +1,79 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.github.com/users/BrennanAyers
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - token <GITHUB-TOKEN>
+      User-Agent:
+      - Faraday v0.12.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 09 Jul 2019 21:25:42 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4987'
+      X-Ratelimit-Reset:
+      - '1562711142'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding
+      Etag:
+      - W/"ca78edd9fb0febe4d47227d2d5dc4cb7"
+      Last-Modified:
+      - Wed, 03 Jul 2019 21:59:38 GMT
+      X-Oauth-Scopes:
+      - repo
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - ED60:3E91:121F8:1AD94:5D250655
+    body:
+      encoding: ASCII-8BIT
+      string: '{"login":"BrennanAyers","id":45154998,"node_id":"MDQ6VXNlcjQ1MTU0OTk4","avatar_url":"https://avatars0.githubusercontent.com/u/45154998?v=4","gravatar_id":"","url":"https://api.github.com/users/BrennanAyers","html_url":"https://github.com/BrennanAyers","followers_url":"https://api.github.com/users/BrennanAyers/followers","following_url":"https://api.github.com/users/BrennanAyers/following{/other_user}","gists_url":"https://api.github.com/users/BrennanAyers/gists{/gist_id}","starred_url":"https://api.github.com/users/BrennanAyers/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/BrennanAyers/subscriptions","organizations_url":"https://api.github.com/users/BrennanAyers/orgs","repos_url":"https://api.github.com/users/BrennanAyers/repos","events_url":"https://api.github.com/users/BrennanAyers/events{/privacy}","received_events_url":"https://api.github.com/users/BrennanAyers/received_events","type":"User","site_admin":false,"name":"Brennan","company":null,"blog":"","location":null,"email":null,"hireable":null,"bio":null,"public_repos":45,"public_gists":12,"followers":4,"following":2,"created_at":"2018-11-19T01:14:36Z","updated_at":"2019-07-03T21:59:38Z"}'
+    http_version: 
+  recorded_at: Tue, 09 Jul 2019 21:25:40 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/send-email-invalid.yml
+++ b/spec/cassettes/send-email-invalid.yml
@@ -1,0 +1,70 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.github.com/users/sdfgrghwetwertwerwerertewt
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - token <GITHUB-TOKEN>
+      User-Agent:
+      - Faraday v0.12.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 09 Jul 2019 21:25:42 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - GitHub.com
+      Status:
+      - 404 Not Found
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4986'
+      X-Ratelimit-Reset:
+      - '1562711142'
+      X-Oauth-Scopes:
+      - repo
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - ED61:1291:8DB5:CC73:5D250656
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"Not Found","documentation_url":"https://developer.github.com/v3/users/#get-a-single-user"}'
+    http_version: 
+  recorded_at: Tue, 09 Jul 2019 21:25:41 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/send-email-success.yml
+++ b/spec/cassettes/send-email-success.yml
@@ -1,0 +1,80 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.github.com/users/WHomer
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - token <GITHUB-TOKEN>
+      User-Agent:
+      - Faraday v0.12.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 09 Jul 2019 21:14:13 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4999'
+      X-Ratelimit-Reset:
+      - '1562710453'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding
+      Etag:
+      - W/"3895653ad9fc617c4e0bb38dd4ea3aee"
+      Last-Modified:
+      - Wed, 03 Jul 2019 21:32:55 GMT
+      X-Oauth-Scopes:
+      - repo
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - EC45:2779:2F0E6:47D95:5D2503A4
+    body:
+      encoding: ASCII-8BIT
+      string: '{"login":"WHomer","id":18176968,"node_id":"MDQ6VXNlcjE4MTc2OTY4","avatar_url":"https://avatars1.githubusercontent.com/u/18176968?v=4","gravatar_id":"","url":"https://api.github.com/users/WHomer","html_url":"https://github.com/WHomer","followers_url":"https://api.github.com/users/WHomer/followers","following_url":"https://api.github.com/users/WHomer/following{/other_user}","gists_url":"https://api.github.com/users/WHomer/gists{/gist_id}","starred_url":"https://api.github.com/users/WHomer/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/WHomer/subscriptions","organizations_url":"https://api.github.com/users/WHomer/orgs","repos_url":"https://api.github.com/users/WHomer/repos","events_url":"https://api.github.com/users/WHomer/events{/privacy}","received_events_url":"https://api.github.com/users/WHomer/received_events","type":"User","site_admin":false,"name":"William
+        Homer","company":null,"blog":"","location":"Denver, CO","email":"billyhomeriii@gmail.com","hireable":true,"bio":null,"public_repos":75,"public_gists":7,"followers":6,"following":2,"created_at":"2016-03-30T21:08:50Z","updated_at":"2019-07-03T21:32:55Z"}'
+    http_version: 
+  recorded_at: Tue, 09 Jul 2019 21:14:11 GMT
+recorded_with: VCR 4.0.0

--- a/spec/features/user/user_can_send_email_invites_spec.rb
+++ b/spec/features/user/user_can_send_email_invites_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe 'As a registered user' do

--- a/spec/features/user/user_can_send_email_invites_spec.rb
+++ b/spec/features/user/user_can_send_email_invites_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe 'As a registered user' do
+  describe 'when I visit my dashboard' do
+    before :each do
+      @user = create(:user)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+
+      VCR.use_cassette('github_dashboard') do
+        visit dashboard_path
+      end
+    end
+
+    it "I see a link to 'Send an Invite'" do
+      expect(page).to have_link('Send an Invite')
+    end
+
+    describe "and click 'Send an Invite'" do
+      before :each do
+        click_link 'Send an Invite'
+      end
+
+      it "I'm navigated to a page with a form to fill in a GitHub handle" do
+        expect(current_path).to eq(invite_path)
+
+        expect(page).to have_field(:github_handle)
+        expect(page).to have_button('Send Invite')
+      end
+    end
+  end
+end
+
+
+
+# Background: We want to be able to enter a user's Github handle and send them an email invite to our app. You'll use the Github API to retrieve the email address of the invitee.
+#
+# As a registered user
+# When I visit /dashboard
+# And I click "Send an Invite"
+# Then I should be on /invite
+#
+# And when I fill in "Github Handle" with <A VALID GITHUB HANDLE>
+# And I click on "Send Invite"
+# Then I should be on /dashboard
+# And I should see a message that says "Successfully sent invite!" (if the user has an email address associated with their github account)
+# Or I should see a message that says "The Github user you selected doesn't have an email address associated with their account."

--- a/spec/features/user/user_can_send_email_invites_spec.rb
+++ b/spec/features/user/user_can_send_email_invites_spec.rb
@@ -26,19 +26,51 @@ RSpec.describe 'As a registered user' do
         expect(page).to have_field(:github_handle)
         expect(page).to have_button('Send Invite')
       end
+
+      describe 'and fill in form with a valid GitHub handle and submit' do
+        it "I'm navigated back to my dashboard and see a success message" do
+          fill_in :github_handle, with: 'WHomer'
+
+          VCR.use_cassette('send-email-success') do
+            click_button 'Send Invite'
+          end
+
+          expect(current_path).to eq(dashboard_path)
+          expect(page).to have_content('Successfully sent invite!')
+        end
+      end
+
+      describe 'and fill in form with valid GitHub handle with no public email' do
+        it "I'm navigated back to my dashboard and see a failure message" do
+          fill_in :github_handle, with: 'BrennanAyers'
+
+          VCR.use_cassette('send-email-failure') do
+            click_button 'Send Invite'
+          end
+
+          expect(current_path).to eq(dashboard_path)
+          expect(page).to have_content("The Github user you selected doesn't have an email address associated with their account.")
+        end
+      end
+
+      describe 'and fill in form with an invalid GitHub handle' do
+        it "I'm navigated back to my dashboard and see a failure message" do
+          fill_in :github_handle, with: 'sdfgrghwetwertwerwerertewt'
+
+          VCR.use_cassette('send-email-invalid') do
+            click_button 'Send Invite'
+          end
+
+          expect(current_path).to eq(dashboard_path)
+          expect(page).to have_content("The Github user you selected doesn't have an email address associated with their account.")
+        end
+      end
     end
   end
 end
 
-
-
 # Background: We want to be able to enter a user's Github handle and send them an email invite to our app. You'll use the Github API to retrieve the email address of the invitee.
-#
-# As a registered user
-# When I visit /dashboard
-# And I click "Send an Invite"
-# Then I should be on /invite
-#
+
 # And when I fill in "Github Handle" with <A VALID GITHUB HANDLE>
 # And I click on "Send Invite"
 # Then I should be on /dashboard

--- a/spec/mailers/invite_mailer_spec.rb
+++ b/spec/mailers/invite_mailer_spec.rb
@@ -21,8 +21,16 @@ RSpec.describe InviteMailer, type: :mailer do
       expect(@mail.from).to eq(['no-reply@brownest-field.herokuapp.com'])
     end
 
-    # it 'renders the body' do
-    #   expect(@mail.body.encoded).to match("Hello #{@invitee.name}, #{@user.github_login} has invited you to join the Brownest Field project. You can create an account <a href='http://localhost:3000/register'>here.</a>")
-    # end
+    it 'assigns @name' do
+      expect(@mail.body.encoded).to match(@user.github_login)
+    end
+
+    it 'assigns @github_login' do
+      expect(@mail.body.encoded).to match(@invitee.name)
+    end
+
+    it 'assigns register_url' do
+      expect(@mail.body.encoded).to match('http://localhost:3000/register')
+    end
   end
 end

--- a/spec/mailers/invite_mailer_spec.rb
+++ b/spec/mailers/invite_mailer_spec.rb
@@ -25,11 +25,11 @@ RSpec.describe InviteMailer, type: :mailer do
       expect(@mail.body.encoded).to match('has invited you to join the Brownest Field project. You can create an account')
     end
 
-    it 'assigns @name' do
+    it 'assigns @github_login' do
       expect(@mail.body.encoded).to match(@user.github_login)
     end
 
-    it 'assigns @github_login' do
+    it 'assigns @name' do
       expect(@mail.body.encoded).to match(@invitee.name)
     end
 

--- a/spec/mailers/invite_mailer_spec.rb
+++ b/spec/mailers/invite_mailer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe InviteMailer, type: :mailer do
@@ -7,7 +9,7 @@ RSpec.describe InviteMailer, type: :mailer do
 
       invitee_info = { login: 'sweetactions',
                        html_url: 'https://github.com/high_voltage_when_we_touch',
-                       id: 12345,
+                       id: 12_345,
                        email: 'sweet@actions.com' }
 
       @invitee = GitHub::User.new(invitee_info)

--- a/spec/mailers/invite_mailer_spec.rb
+++ b/spec/mailers/invite_mailer_spec.rb
@@ -21,6 +21,10 @@ RSpec.describe InviteMailer, type: :mailer do
       expect(@mail.from).to eq(['no-reply@brownest-field.herokuapp.com'])
     end
 
+    it 'renders the body' do
+      expect(@mail.body.encoded).to match('has invited you to join the Brownest Field project. You can create an account')
+    end
+
     it 'assigns @name' do
       expect(@mail.body.encoded).to match(@user.github_login)
     end

--- a/spec/mailers/invite_mailer_spec.rb
+++ b/spec/mailers/invite_mailer_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe InviteMailer, type: :mailer do
+  describe 'invite_email' do
+    before :each do
+      @user = create(:user, github_login: 'smelphy_io')
+
+      invitee_info = { login: 'sweetactions',
+                       html_url: 'https://github.com/high_voltage_when_we_touch',
+                       id: 12345,
+                       email: 'sweet@actions.com' }
+
+      @invitee = GitHub::User.new(invitee_info)
+
+      @mail = InviteMailer.invite_email(@user, @invitee)
+    end
+
+    it 'renders the headers' do
+      expect(@mail.subject).to eq("#{@user.github_login} has invited you to join the Brownfield project!")
+      expect(@mail.to).to eq([@invitee.email])
+      expect(@mail.from).to eq(['no-reply@brownest-field.herokuapp.com'])
+    end
+
+    # it 'renders the body' do
+    #   expect(@mail.body.encoded).to match("Hello #{@invitee.name}, #{@user.github_login} has invited you to join the Brownest Field project. You can create an account <a href='http://localhost:3000/register'>here.</a>")
+    # end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'simplecov'
 SimpleCov.start
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,3 +1,6 @@
+require 'simplecov'
+SimpleCov.start
+
 require 'spec_helper'
 
 ENV['RAILS_ENV'] ||= 'test'
@@ -29,8 +32,6 @@ Capybara.javascript_driver = :selenium_chrome
 Capybara.configure do |config|
   config.default_max_wait_time = 5
 end
-
-SimpleCov.start "rails"
 
 Shoulda::Matchers.configure do |config|
     config.integrate do |with|


### PR DESCRIPTION
This PR adds email invitations to the user dashboard.

- Adds feature spec for user being able to send email invitations
- Adds InviteMailer with invite_email method, HTML/text views and spec
- Adds InviteController with new/create actions and new view
- Adds user_query instance method to GitHub service
- Adds SMTP configuration to development/test environments
- Adds SendGrid API key and configuration for production

SimpleCov has also been moved to its appropriate location at the top of rails_helper, test coverage has been bumped from 10% to 98% after the fix.