### PR TITLE
Friends Helping Friends

### DIFF
--- a/app/models/friendship.rb
+++ b/app/models/friendship.rb
@@ -3,4 +3,14 @@
 class Friendship < ApplicationRecord
   belongs_to :user
   belongs_to :friend, class_name: 'User'
+
+  validate :real_friends
+  validates_presence_of :user_id, :friend_id
+
+  private
+
+  def real_friends
+    return unless user_id == friend_id
+    errors.add :user, "I guess I get what I deserve, don't I?"
+  end
 end

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -29,6 +29,7 @@ class GithubService
   def conn
     Faraday.new(url: 'https://api.github.com') do |f|
       f.headers['Authorization'] = "token #{@user_token}"
+      f.headers['Accept'] = 'v3'
       f.adapter Faraday.default_adapter
     end
   end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,4 +1,6 @@
 Rails.application.configure do
+  config.action_mailer.default_url_options = { host: 'https://brownest-field.herokuapp.com/' }
+
   # Verifies that versions and hashed value of the package contents in the project's package.json
   config.webpacker.check_yarn_integrity = false
   # Settings specified here will take precedence over those in config/application.rb.

--- a/spec/models/friendship_spec.rb
+++ b/spec/models/friendship_spec.rb
@@ -3,8 +3,23 @@
 require 'rails_helper'
 
 RSpec.describe Friendship, type: :model do
+  describe 'validations' do
+    it { should validate_presence_of :user_id }
+    it { should validate_presence_of :friend_id }
+  end
+
   describe 'relationships' do
     it { should belong_to :user }
     it { should belong_to :friend }
+  end
+
+  describe 'instance method' do
+    it '#real_friends' do
+      user = create(:user)
+      friendship = Friendship.new(user: user, friend: user)
+
+      expect(friendship.save).to be(false)
+      expect(friendship.errors.messages[:user].first).to eq("I guess I get what I deserve, don't I?")
+    end
   end
 end


### PR DESCRIPTION
This PR updates the Friendship model with validations for user_id and friend_id.  Additionally, an instance method real_friends has been added to prevent a user from friending themself.

GithubService Faraday connection has been refactored to utilize 'v3' of the GitHub API, rather than the default version.