### PR TITLE
Tutorial Dependent Destroy

### DIFF
--- a/app/models/tutorial.rb
+++ b/app/models/tutorial.rb
@@ -1,5 +1,5 @@
 class Tutorial < ApplicationRecord
-  has_many :videos, ->  { order(position: :ASC) }
+  has_many :videos, -> { order(position: :asc) }, dependent: :destroy
   acts_as_taggable_on :tags, :tag_list
   accepts_nested_attributes_for :videos
 

--- a/spec/models/tutorial_spec.rb
+++ b/spec/models/tutorial_spec.rb
@@ -4,6 +4,13 @@ RSpec.describe Tutorial, type: :model do
   describe 'relationships' do
     it { should have_many :videos }
     it { should accept_nested_attributes_for :videos }
+
+    it 'destroys dependent videos' do
+      tutorial = create(:tutorial)
+      create_list(:video, 4, tutorial: tutorial)
+
+      expect { tutorial.destroy }.to change { Video.count }.by(-4)
+    end
   end
 
   describe 'instance methods' do


### PR DESCRIPTION
This PR adds dependent: :destroy for Tutorial Videos.  A spec has been added as well.