### PR TITLE
RuboCop/Hound Configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,14 @@
+AllCops:
+  Exclude:
+    - 'db/**/*'
+    - 'config/**/*'
+    - 'script/**/*'
+    - 'bin/{rails,rake}'
+
+Metrics/LineLength:
+  Exclude:
+    - 'spec'
+
+Metrics/BlockLength:
+  Exclude:
+    - 'spec'


### PR DESCRIPTION
This PR brings in a configuration for Hound to follow when checking our Ruby using Rubocop.
I used the base 'ignore Rails things' block from Rubocops documentation, which ignores everything in Config files, DB files, Script files, and `bin` files.
I also added Line Length and Block Length exclusions to the Spec folder, as our tests require blocks to be longer than that, and contain lots of strings to be expected leading to over 80 characters.