### PR TITLE
Add User Spec Coverage

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,8 +12,6 @@ class User < ApplicationRecord
   enum role: [:default, :admin]
   has_secure_password
 
-  # instance methods
-
   def connect_github(auth_hash)
     update_attributes(github_token: auth_hash[:credentials][:token])
     update_attributes(github_login: auth_hash[:login])

--- a/spec/models/git_hub/user_spec.rb
+++ b/spec/models/git_hub/user_spec.rb
@@ -5,7 +5,8 @@ require 'rails_helper'
 RSpec.describe GitHub::User do
   before :each do
     attributes = { login: 'Joey Bagodonuts',
-                   html_url: 'https://joeytime.com' }
+                   html_url: 'https://joeytime.com',
+                   id: 'dangerous' }
 
     @user = GitHub::User.new(attributes)
   end
@@ -17,5 +18,15 @@ RSpec.describe GitHub::User do
   it 'attributes' do
     expect(@user.name).to eq('Joey Bagodonuts')
     expect(@user.html_url).to eq('https://joeytime.com')
+  end
+
+  describe 'instance methods' do
+    it '#registered?' do
+      create(:user, github_uid: 'dangerous')
+      unregistered_user = GitHub::User.new(id: '12345')
+
+      expect(@user.registered?).to eq(true)
+      expect(unregistered_user.registered?).to eq(false)
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -53,5 +53,41 @@ RSpec.describe User, type: :model do
       expect(user.github_uid.to_i).to eq(auth_hash[:uid])
       expect(user.github_token).to eq(auth_hash[:credentials][:token])
     end
+
+    it '#friendships' do
+      user_1 = create(:user)
+      user_2 = create(:user)
+
+      user_1.friendships.create!(friend: user_2)
+
+      expect(user_1.friendships?).to eq(true)
+      expect(user_2.friendships?).to eq(false)
+
+      user_2.friendships.create!(friend: user_1)
+
+      expect(user_2.friendships?).to eq(true)
+    end
+
+    it '#friends?' do
+      user_1 = create(:user, github_uid: '12345')
+      user_2 = create(:user, github_uid: '54321')
+      create(:user, github_uid: '67890')
+
+      github_friend = GitHub::User.new(id: '54321')
+      github_not_friend = GitHub::User.new(id: '67890')
+
+      user_1.friendships.create!(friend: user_2)
+
+      expect(user_1.friends?(github_friend)).to eq(true)
+      expect(user_1.friends?(github_not_friend)).to eq(false)
+    end
+
+    it '#email_status' do
+      user_1 = create(:user, verified_email: true)
+      user_2 = create(:user, verified_email: false)
+
+      expect(user_1.email_status).to eq('Verified!')
+      expect(user_2.email_status).to eq('This account has not yet been verified. Please check your email.')
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -55,39 +55,39 @@ RSpec.describe User, type: :model do
     end
 
     it '#friendships' do
-      user_1 = create(:user)
-      user_2 = create(:user)
+      user1 = create(:user)
+      user2 = create(:user)
 
-      user_1.friendships.create!(friend: user_2)
+      user1.friendships.create!(friend: user2)
 
-      expect(user_1.friendships?).to eq(true)
-      expect(user_2.friendships?).to eq(false)
+      expect(user1.friendships?).to eq(true)
+      expect(user2.friendships?).to eq(false)
 
-      user_2.friendships.create!(friend: user_1)
+      user2.friendships.create!(friend: user1)
 
-      expect(user_2.friendships?).to eq(true)
+      expect(user2.friendships?).to eq(true)
     end
 
     it '#friends?' do
-      user_1 = create(:user, github_uid: '12345')
-      user_2 = create(:user, github_uid: '54321')
+      user1 = create(:user, github_uid: '12345')
+      user2 = create(:user, github_uid: '54321')
       create(:user, github_uid: '67890')
 
       github_friend = GitHub::User.new(id: '54321')
       github_not_friend = GitHub::User.new(id: '67890')
 
-      user_1.friendships.create!(friend: user_2)
+      user1.friendships.create!(friend: user2)
 
-      expect(user_1.friends?(github_friend)).to eq(true)
-      expect(user_1.friends?(github_not_friend)).to eq(false)
+      expect(user1.friends?(github_friend)).to eq(true)
+      expect(user1.friends?(github_not_friend)).to eq(false)
     end
 
     it '#email_status' do
-      user_1 = create(:user, verified_email: true)
-      user_2 = create(:user, verified_email: false)
+      user1 = create(:user, verified_email: true)
+      user2 = create(:user, verified_email: false)
 
-      expect(user_1.email_status).to eq('Verified!')
-      expect(user_2.email_status).to eq('This account has not yet been verified. Please check your email.')
+      expect(user1.email_status).to eq('Verified!')
+      expect(user2.email_status).to eq('This account has not yet been verified. Please check your email.')
     end
   end
 end


### PR DESCRIPTION
This PR adds specs for #friends?, #friendship? and #email_status in User model.  Also, a spec for #registered in the GitHub::User PORO has been added.