### PR TITLE
Controller Cleanup

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,7 +1,7 @@
 class Admin::BaseController < ApplicationController
-  before_action :require_admin!
+  before_action :require_admin
 
-  def require_admin!
-    four_oh_four unless current_user.admin?
+  def require_admin
+    render file: 'public/404', status: 404 unless current_user && current_user.admin?
   end
 end

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -2,6 +2,8 @@ class Admin::BaseController < ApplicationController
   before_action :require_admin
 
   def require_admin
-    render file: 'public/404', status: 404 unless current_user && current_user.admin?
+    unless current_user && current_user.admin?
+      render file: 'public/404', status: 404
+    end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,8 +22,4 @@ class ApplicationController < ActionController::Base
   def tutorial_name(id)
     Tutorial.find(id).title
   end
-
-  def four_oh_four
-    raise ActionController::RoutingError.new('Not Found')
-  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -22,6 +22,7 @@ class UsersController < ApplicationController
       VerificationMailer.verification_email(user).deliver_now
     else
       flash[:error] = 'Username already exists'
+      @user = User.new(user_params)
       render :new
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class UsersController < ApplicationController
+  before_action :require_current_user, only: :show
 
   def show
     render locals: {

--- a/spec/features/visitors/visitor_can_register_spec.rb
+++ b/spec/features/visitors/visitor_can_register_spec.rb
@@ -1,12 +1,11 @@
 require 'rails_helper'
 
-describe 'vister can create an account', :js do
+describe 'visitor can create an account', :js do
   it ' visits the home page' do
     email = 'jimbob@aol.com'
     first_name = 'Jim'
     last_name = 'Bob'
     password = 'password'
-    password_confirmation = 'password'
 
     visit '/'
 
@@ -32,5 +31,29 @@ describe 'vister can create an account', :js do
     expect(page).to have_content(first_name)
     expect(page).to have_content(last_name)
     expect(page).to_not have_content('Sign In')
+  end
+end
+
+describe 'visitor can not create an already existing account', :js do
+  it ' visits the register page' do
+    create(:user, email: 'jimbob@aol.com')
+    email = 'jimbob@aol.com'
+    first_name = 'Jim'
+    last_name = 'Bob'
+    password = 'password'
+
+    visit new_user_path
+
+    fill_in 'user[email]', with: email
+    fill_in 'user[first_name]', with: first_name
+    fill_in 'user[last_name]', with: last_name
+    fill_in 'user[password]', with: password
+    fill_in 'user[password_confirmation]', with: password
+
+    click_on'Create Account'
+
+    expect(current_path).to eq(users_path)
+
+    expect(page).to have_content('Username already exists')
   end
 end


### PR DESCRIPTION
PR in Progress

This PR fixes an issue where a non signed in user could access the `/dashboard` path, but instead of seeing a 404 page, they would get a major error. The UserController#show action now requires_current_user before making any action.
Also refactored/removed the `four_oh_four` method on the Admin::BaseController, as it should have just been rendering a 404 instead of raising an exception when the user was not an admin. Now users can gracefully navigate to all the places they don't belong and will be greeted with the normal message.