### PR TITLE
Admin creates New Tutorial

### DIFF
--- a/app/controllers/admin/tutorials_controller.rb
+++ b/app/controllers/admin/tutorials_controller.rb
@@ -4,6 +4,12 @@ class Admin::TutorialsController < Admin::BaseController
   end
 
   def create
+    tutorial = Tutorial.new(tutorial_params)
+
+    if tutorial.save
+      flash[:success] = 'Successfully created tutorial.'
+    end
+    redirect_to tutorial_path(tutorial)
   end
 
   def new
@@ -12,7 +18,7 @@ class Admin::TutorialsController < Admin::BaseController
 
   def update
     tutorial = Tutorial.find(params[:id])
-    if tutorial.update(tutorial_params)
+    if tutorial.update(tutorial_tag_params)
       flash[:success] = "#{tutorial.title} tagged!"
     end
     redirect_to edit_admin_tutorial_path(tutorial)
@@ -20,6 +26,10 @@ class Admin::TutorialsController < Admin::BaseController
 
   private
   def tutorial_params
+    params.require(:tutorial).permit(:title, :description, :thumbnail)
+  end
+  
+  def tutorial_tag_params
     params.require(:tutorial).permit(:tag_list)
   end
 end

--- a/app/controllers/admin/tutorials_controller.rb
+++ b/app/controllers/admin/tutorials_controller.rb
@@ -4,12 +4,15 @@ class Admin::TutorialsController < Admin::BaseController
   end
 
   def create
-    tutorial = Tutorial.new(tutorial_params)
+    @tutorial = Tutorial.new(tutorial_params)
 
-    if tutorial.save
+    if @tutorial.save
       flash[:success] = 'Successfully created tutorial.'
+      redirect_to tutorial_path(id: @tutorial.id)
+    else
+      flash[:warning] = 'Please use a valid Youtube video thumbnail.'
+      render new_admin_tutorial_path
     end
-    redirect_to tutorial_path(tutorial)
   end
 
   def new
@@ -28,7 +31,7 @@ class Admin::TutorialsController < Admin::BaseController
   def tutorial_params
     params.require(:tutorial).permit(:title, :description, :thumbnail)
   end
-  
+
   def tutorial_tag_params
     params.require(:tutorial).permit(:tag_list)
   end

--- a/app/models/tutorial.rb
+++ b/app/models/tutorial.rb
@@ -3,7 +3,7 @@ class Tutorial < ApplicationRecord
   acts_as_taggable_on :tags, :tag_list
   accepts_nested_attributes_for :videos
 
-  validates_format_of :thumbnail, with: %r(\Ahttps:\/\/i\.ytimg\.com\/vi\/([a-zA-Z0-9_-]*)\/hqdefault\.jpg\Z), on: :create
+  validates_format_of :thumbnail, with: %r{ (\Ahttps:\/\/i\.ytimg\.com\/vi\/([a-zA-Z0-9_-]*)\/hqdefault\.jpg\Z) }, on: :create
 
   scope :exclude_classroom, -> { where(classroom: false) }
 

--- a/app/models/tutorial.rb
+++ b/app/models/tutorial.rb
@@ -3,6 +3,8 @@ class Tutorial < ApplicationRecord
   acts_as_taggable_on :tags, :tag_list
   accepts_nested_attributes_for :videos
 
+  validates_format_of :thumbnail, with: /(\Ahttps:\/\/i\.ytimg\.com\/vi\/([a-zA-Z0-9_-]*)\/hqdefault\.jpg\Z)/, on: :create
+
   scope :exclude_classroom, -> { where(classroom: false) }
 
   def classroom?

--- a/app/models/tutorial.rb
+++ b/app/models/tutorial.rb
@@ -3,7 +3,7 @@ class Tutorial < ApplicationRecord
   acts_as_taggable_on :tags, :tag_list
   accepts_nested_attributes_for :videos
 
-  validates_format_of :thumbnail, with: /(\Ahttps:\/\/i\.ytimg\.com\/vi\/([a-zA-Z0-9_-]*)\/hqdefault\.jpg\Z)/, on: :create
+  validates_format_of :thumbnail, with: %r(\Ahttps:\/\/i\.ytimg\.com\/vi\/([a-zA-Z0-9_-]*)\/hqdefault\.jpg\Z), on: :create
 
   scope :exclude_classroom, -> { where(classroom: false) }
 

--- a/spec/factories/tutorials.rb
+++ b/spec/factories/tutorials.rb
@@ -2,14 +2,14 @@ FactoryBot.define do
   factory :tutorial do
     title { Faker::Name.unique.name }
     description { Faker::HitchhikersGuideToTheGalaxy.marvin_quote }
-    thumbnail { 'http://cdn3-www.dogtime.com/assets/uploads/2011/03/puppy-development-460x306.jpg' }
+    thumbnail { 'https://i.ytimg.com/vi/CStwQXbTa7c/hqdefault.jpg' }
     playlist_id { Faker::Crypto.md5 }
   end
 
   factory :classroom_tutorial, parent: :tutorial do
     title { Faker::Name.unique.name }
     description { Faker::HitchhikersGuideToTheGalaxy.marvin_quote }
-    thumbnail { 'http://cdn3-www.dogtime.com/assets/uploads/2011/03/puppy-development-460x306.jpg' }
+    thumbnail { 'https://i.ytimg.com/vi/CStwQXbTa7c/hqdefault.jpg' }
     playlist_id { Faker::Crypto.md5 }
     classroom { true }
   end

--- a/spec/features/admin/new_tutorial_spec.rb
+++ b/spec/features/admin/new_tutorial_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe 'As an Admin user', type: :feature do
+  context 'when I visit the new tutorial page' do
+    before :each do
+      @admin = create(:user, role: 1)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
+    end
+
+    it 'I can create a new tutorial' do
+      visit new_admin_tutorial_path
+
+      fill_in 'tutorial[title]', with: 'How to Learn like a Learner'
+      fill_in 'tutorial[description]', with: 'Now with new Learnings!'
+      fill_in 'tutorial[thumbnail]', with: 'https://i.ytimg.com/vi/Drqj67ImtxI/hqdefault.jpg'
+
+      click_on 'Save'
+
+      new_tutorial = Tutorial.last
+      expect(current_path).to eq(tutorial_path(id: new_tutorial.id))
+
+      expect(page).to have_content('Successfully created tutorial.')
+
+      expect(page).to have_content('How to Learn like a Learner')
+      expect(page).to have_content('There are no videos in this tutorial yet!')
+
+      visit root_path
+
+      expect(page).to have_content('Now with new Learnings!')
+      expect(page).to have_css("img[src='https://i.ytimg.com/vi/Drqj67ImtxI/hqdefault.jpg']")
+    end
+  end
+end

--- a/spec/features/admin/new_tutorial_spec.rb
+++ b/spec/features/admin/new_tutorial_spec.rb
@@ -29,5 +29,20 @@ RSpec.describe 'As an Admin user', type: :feature do
       expect(page).to have_content('Now with new Learnings!')
       expect(page).to have_css("img[src='https://i.ytimg.com/vi/Drqj67ImtxI/hqdefault.jpg']")
     end
+
+    it 'I fail to create a bad tutorial' do
+      visit new_admin_tutorial_path
+
+      fill_in 'tutorial[title]', with: 'How to Learn like a Learner'
+      fill_in 'tutorial[description]', with: 'Now with new Learnings!'
+      fill_in 'tutorial[thumbnail]', with: 'https://www.notavalid.com/youtube/thumbnmail.jpg'
+
+      click_on 'Save'
+
+      expect(current_path).to eq(admin_tutorials_path)
+
+      expect(page).to have_content('Please use a valid Youtube video thumbnail.')
+      expect(Tutorial.count).to eq(0)
+    end
   end
 end

--- a/spec/models/tutorial_spec.rb
+++ b/spec/models/tutorial_spec.rb
@@ -13,6 +13,11 @@ RSpec.describe Tutorial, type: :model do
     end
   end
 
+  describe 'validations' do
+    it { should allow_value('https://i.ytimg.com/vi/fwueifn1368/hqdefault.jpg').for(:thumbnail) }
+    it { should_not allow_value('https://i.ytimg.com/vi/&%^@#&%^/hqdefault.jpg').for(:thumbnail) }
+  end
+
   describe 'instance methods' do
     it '#classroom?' do
       t1 = create(:classroom_tutorial)


### PR DESCRIPTION
This PR brings in the correct functionality for an Admin user to create a new Tutorial. Prior, the route and pages were there, but the action to #create was empty.
This creation flow is your usual steps, including a validation on a new Tutorial having a valid Youtube video thumbnail image. There is a regex to determine validity inside the model.
We have also updated the `tutorial_params` strong params private method in the controller to refer to ONLY the Tags, as thats what it was being used for previously. There is now a separate `tutorial_params` method that follows the normal creation format.
The Tutorial factory has also been updated with the correct YTimg format.

resolves #1 