### PR TITLE
Hound Config part 3

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,2 @@
+rubocop:
+  config_file: .rubocop.yml


### PR DESCRIPTION
Add Hound Config file to tell it to use .rubocop.yml